### PR TITLE
Set kafka property `specific.avro.reader` to true

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,8 @@ spring:
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
+      properties:
+        specific.avro.reader: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer


### PR DESCRIPTION
The property `specific.avro.reader` defaults to false. This means it is deserialising data into a generic record and not using the specific record implementation that was generated by the maven plugin until the property is explicitly set to true.